### PR TITLE
bump kernel and linux firmware versions

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -37,10 +37,10 @@ ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
 # https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/disco
-ARG KERNEL_SOURCE_URL=http://archive.ubuntu.com/ubuntu/pool/main/l/linux/linux-source-4.15.0_4.15.0-47.50_all.deb
+ARG KERNEL_SOURCE_URL=http://archive.ubuntu.com/ubuntu/pool/main/l/linux/linux-source-4.15.0_4.15.0-58.64_all.deb
 
 # https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux-firmware
-ARG FIRMWARE_URL=http://archive.ubuntu.com/ubuntu/pool/main/l/linux-firmware/linux-firmware_1.173.3_all.deb
+ARG FIRMWARE_URL=http://archive.ubuntu.com/ubuntu/pool/main/l/linux-firmware/linux-firmware_1.173.9_all.deb
 
 ENV KERNEL_SOURCE_URL=${KERNEL_SOURCE_URL} \
     FIRMWARE_URL=${FIRMWARE_URL} \


### PR DESCRIPTION
A lot of CVEs have been fixed in the kernel since the last release. Tracking the latest ubuntu kernel and firmware would protect users of k3os. 