### PR TITLE
bionic/lts: hwe/5.0.0

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -37,10 +37,10 @@ ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
 # https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/disco
-ARG KERNEL_SOURCE_URL=http://archive.ubuntu.com/ubuntu/pool/main/l/linux/linux-source-4.15.0_4.15.0-70.79_all.deb
+ARG KERNEL_SOURCE_URL=http://archive.ubuntu.com/ubuntu/pool/main/l/linux-hwe/linux-source-5.0.0_5.0.0-36.39~18.04.1_all.deb
 
 # https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux-firmware
-ARG FIRMWARE_URL=http://archive.ubuntu.com/ubuntu/pool/main/l/linux-firmware/linux-firmware_1.173.9_all.deb
+ARG FIRMWARE_URL=http://archive.ubuntu.com/ubuntu/pool/main/l/linux-firmware/linux-firmware_1.173.12_all.deb
 
 ENV KERNEL_SOURCE_URL=${KERNEL_SOURCE_URL} \
     FIRMWARE_URL=${FIRMWARE_URL} \

--- a/patches/bpfilter-umh.patch
+++ b/patches/bpfilter-umh.patch
@@ -1,0 +1,12 @@
+diff -urbB kernel.unpatched/debian.hwe/config/config.common.ubuntu kernel/debian.hwe/config/config.common.ubuntu
+--- kernel.unpatched/debian.hwe/config/config.common.ubuntu	2019-09-30 22:23:05.000000000 +0000
++++ kernel/debian.hwe/config/config.common.ubuntu	2019-10-15 01:24:35.804607723 +0000
+@@ -1121,7 +1121,7 @@
+ CONFIG_BOOT_PRINTK_DELAY=y
+ CONFIG_BPF=y
+ CONFIG_BPFILTER=y
+-CONFIG_BPFILTER_UMH=m
++CONFIG_BPFILTER_UMH=y
+ CONFIG_BPF_EVENTS=y
+ CONFIG_BPF_JIT=y
+ CONFIG_BPF_KPROBE_OVERRIDE=y

--- a/patches/readme.md
+++ b/patches/readme.md
@@ -1,0 +1,3 @@
+# Patches
+
+Drop your patches, ending in `.patch`, into this directory for them to be applied automatically during builds.

--- a/scripts/build
+++ b/scripts/build
@@ -8,11 +8,16 @@ KERNEL_DIR=build/kernel
 
 # some hacking
 mkdir -p ${KERNEL_DIR}/debian/stamps
-
+chmod -R +x ${KERNEL_DIR}/debian/scripts
 
 # kernel
 pushd ${KERNEL_DIR}
-fakeroot debian/rules clean
-fakeroot debian/rules binary-headers binary-generic do_zfs=false do_dkms_nvidia=false
+debian/rules clean
+# see https://wiki.ubuntu.com/KernelTeam/KernelMaintenance#Overriding_module_check_failures
+for abi in $(find . -mindepth 1 -maxdepth 2 -type d -name abi); do
+    for ver in $abi/5.*; do
+        echo bpfilter > $ver/modules.ignore
+    done
+done
+debian/rules binary-headers binary-generic do_zfs=false do_dkms_nvidia=false #skipmodule=true
 popd
-

--- a/scripts/download
+++ b/scripts/download
@@ -10,22 +10,20 @@ mkdir -p ${DOWNLOADS}/kernel ${DOWNLOADS}/firmware
 mkdir -p build/kernel
 curl -fL -o ${DOWNLOADS}/ubuntu-kernel.deb ${KERNEL_SOURCE_URL}
 dpkg-deb -x ${DOWNLOADS}/ubuntu-kernel.deb ${DOWNLOADS}/kernel
-mv ${DOWNLOADS}/kernel/usr/src/linux-source-*/debian* ./build/kernel
-tar xf ${DOWNLOADS}/kernel/usr/src/linux-source-*/linux-source*.tar.bz2 -C /tmp
-mv /tmp/linux-source-*/* ./build/kernel
+rsync -a ${DOWNLOADS}/kernel/usr/src/linux-source-*/debian* ./build/kernel/
+tar xf ${DOWNLOADS}/kernel/usr/src/linux-source-*/linux-source*.tar.bz2 -C ./build/kernel/. --strip-components=1
 
 # firmware
 mkdir -p build/firmware
 curl -fL -o ${DOWNLOADS}/ubuntu-firmware.deb ${FIRMWARE_URL}
 dpkg-deb -x ${DOWNLOADS}/ubuntu-firmware.deb ${DOWNLOADS}/firmware
-mv ${DOWNLOADS}/firmware/lib/firmware/* ./build/firmware
+rsync -a ${DOWNLOADS}/firmware/lib/firmware/* ./build/firmware/
 
 # patches
 PATCHES_DIR=$(pwd)/patches
 pushd build/kernel
 for p in `find ${PATCHES_DIR} -name "*.patch"`; do
-    echo "patching $p"
+    echo "applying $p"
     patch -p1 -i $p
 done
 popd
-

--- a/scripts/package
+++ b/scripts/package
@@ -14,39 +14,34 @@ KERNEL_BASE_DIR=build/kernel/debian
 FIRMWARE_BASE_DIR=build/firmware
 
 # headers
-headerdir=$(basename ${KERNEL_BASE_DIR}/linux-headers-*[0-9])
-mkdir -p ${GENERIC_HEADERS_DIR}/$headerdir
-cp -rf ${KERNEL_BASE_DIR}/linux-headers-*[0-9]/usr ${GENERIC_HEADERS_DIR}/$headerdir
-gheaderdir=$(basename ${KERNEL_BASE_DIR}/linux-headers-*-generic)
-mkdir -p ${GENERIC_HEADERS_DIR}/$gheaderdir
-cp -rf ${KERNEL_BASE_DIR}/linux-headers-*-generic/usr ${GENERIC_HEADERS_DIR}/$gheaderdir
-cp -rf ${KERNEL_BASE_DIR}/linux-headers-*-generic/lib ${GENERIC_HEADERS_DIR}/$gheaderdir
+rsync -av ${KERNEL_BASE_DIR}/linux-headers-*[0-9]/usr/ ${GENERIC_HEADERS_DIR}/usr/
+rsync -av ${KERNEL_BASE_DIR}/linux-headers-*-generic/usr/ ${GENERIC_HEADERS_DIR}/usr/
+rsync -av ${KERNEL_BASE_DIR}/linux-headers-*-generic/lib/ ${GENERIC_HEADERS_DIR}/lib/
 
 # main modules and vmlinuz and firmware
 IMAGE_GENERIC_DIR=${KERNEL_BASE_DIR}/linux-image-unsigned-*-generic
 if [ ! -d ${IMAGE_GENERIC_DIR} ]; then
     IMAGE_GENERIC_DIR=${KERNEL_BASE_DIR}/linux-image-*-generic
 fi
-cp -rf ${IMAGE_GENERIC_DIR}/boot ${GENERIC_MAIN_DIR}
-cp -rf ${KERNEL_BASE_DIR}/linux-modules-*-generic/boot ${GENERIC_MAIN_DIR}
-cp -rf ${KERNEL_BASE_DIR}/linux-modules-*-generic/lib ${GENERIC_MAIN_DIR}
-mkdir -p ${GENERIC_MAIN_DIR}/lib/firmware
-cp -rf ${FIRMWARE_BASE_DIR}/* ${GENERIC_MAIN_DIR}/lib/firmware
+rsync -av ${IMAGE_GENERIC_DIR}/boot/ ${GENERIC_MAIN_DIR}/boot/
+rsync -av ${KERNEL_BASE_DIR}/linux-modules-[0-9]*-generic/boot/ ${GENERIC_MAIN_DIR}/boot/
+rsync -av ${KERNEL_BASE_DIR}/linux-modules-[0-9]*-generic/lib/ ${GENERIC_MAIN_DIR}/lib/
+rsync -av ${FIRMWARE_BASE_DIR}/ ${GENERIC_MAIN_DIR}/lib/firmware/
 
 # extra modules
-cp -rf ${KERNEL_BASE_DIR}/linux-modules-extra-*-generic/lib ${GENERIC_EXTRA_DIR}
+rsync -av ${KERNEL_BASE_DIR}/linux-modules-extra-*-generic/lib/ ${GENERIC_EXTRA_DIR}
 
 # package artifacts
 mkdir -p dist/artifacts
 
 pushd ${GENERIC_HEADERS_DIR}
-tar cvJf ../../artifacts/kernel-headers-generic_${ARCH}.tar.xz .
+time sh -xc "tar cJf ../../artifacts/kernel-headers-generic_${ARCH}.tar.xz ."
 popd
 
 pushd ${GENERIC_MAIN_DIR}
-tar cvJf ../../artifacts/kernel-generic_${ARCH}.tar.xz .
+time sh -xc "tar cJf ../../artifacts/kernel-generic_${ARCH}.tar.xz ."
 popd
 
 pushd ${GENERIC_EXTRA_DIR}
-tar cvJf ../../artifacts/kernel-extra-generic_${ARCH}.tar.xz .
+time sh -xc "tar cJf ../../artifacts/kernel-extra-generic_${ARCH}.tar.xz ."
 popd


### PR DESCRIPTION
- latest hwe/5.0.0 kernel as of 2019/11/19
- drops use of `fakeroot` as it doesn't work reliably in a container attached to a tty
- uses `rsync` instead of `cp` during the package phase
