### PR TITLE
ubuntu/bionic/hwe 5.0.0-41.45

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,6 +1,24 @@
-FROM gcc:8.3
-# FROM arm64=arm64v8/gcc:8.3
+ARG APT_GCC=library/gcc:9.2
 
+FROM library/ubuntu:bionic AS bionic
+ARG DOWNLOADS=/usr/src/downloads
+ARG LINUX_FIRMWARE=linux-firmware=1.173.15
+ARG LINUX_SOURCE=linux-source-5.0.0=5.0.0-41.45~18.04.1
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN set -x \
+ && apt-get --assume-yes update \
+ && apt-get --assume-yes download \
+    ${LINUX_FIRMWARE} \
+    ${LINUX_SOURCE} \
+ && mkdir -vp ${DOWNLOADS} \
+ && mv -vf linux-firmware* ${DOWNLOADS}/ubuntu-firmware.deb \
+ && mv -vf linux-source* ${DOWNLOADS}/ubuntu-kernel.deb
+
+
+FROM ${APT_GCC}
+ARG DOWNLOADS=/usr/src/downloads
+COPY --from=bionic ${DOWNLOADS}/ ${DOWNLOADS}/
 RUN apt-get update \
     && apt-get install -y \
         kernel-wedge \
@@ -35,16 +53,7 @@ WORKDIR ${DAPPER_SOURCE}
 ########## General Configuration #####################
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
-
-# https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/disco
-ARG KERNEL_SOURCE_URL=http://archive.ubuntu.com/ubuntu/pool/main/l/linux-hwe/linux-source-5.0.0_5.0.0-37.40~18.04.1_all.deb
-
-# https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux-firmware
-ARG FIRMWARE_URL=http://archive.ubuntu.com/ubuntu/pool/main/l/linux-firmware/linux-firmware_1.173.14_all.deb
-
-ENV KERNEL_SOURCE_URL=${KERNEL_SOURCE_URL} \
-    FIRMWARE_URL=${FIRMWARE_URL} \
-    DOWNLOADS=/usr/src/downloads
+ENV DOWNLOADS ${DOWNLOADS}
 
 ENTRYPOINT ["./scripts/entry"]
 CMD ["ci"]

--- a/scripts/ci
+++ b/scripts/ci
@@ -5,6 +5,6 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 
-./scripts/download
+./scripts/prepare
 ./scripts/build
 ./scripts/package

--- a/scripts/clean
+++ b/scripts/clean
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+rm -rf $(dirname "$0")/../build
+rm -rf $(dirname "$0")/../dist
+rm -f $(dirname "$0")/../Dockerfile.dapper[0-9]*

--- a/scripts/package
+++ b/scripts/package
@@ -10,26 +10,17 @@ GENERIC_EXTRA_DIR=dist/generic/modules-extra
 
 mkdir -p ${GENERIC_HEADERS_DIR} ${GENERIC_MAIN_DIR} ${GENERIC_EXTRA_DIR}
 
-KERNEL_BASE_DIR=build/kernel/debian
-FIRMWARE_BASE_DIR=build/firmware
-
 # headers
-rsync -av ${KERNEL_BASE_DIR}/linux-headers-*[0-9]/usr/ ${GENERIC_HEADERS_DIR}/usr/
-rsync -av ${KERNEL_BASE_DIR}/linux-headers-*-generic/usr/ ${GENERIC_HEADERS_DIR}/usr/
-rsync -av ${KERNEL_BASE_DIR}/linux-headers-*-generic/lib/ ${GENERIC_HEADERS_DIR}/lib/
+dpkg-deb -x build/linux-headers-5.0.*.deb ${GENERIC_HEADERS_DIR}/
+dpkg-deb -x build/linux-hwe-5.0-headers-*.deb ${GENERIC_HEADERS_DIR}/
 
 # main modules and vmlinuz and firmware
-IMAGE_GENERIC_DIR=${KERNEL_BASE_DIR}/linux-image-unsigned-*-generic
-if [ ! -d ${IMAGE_GENERIC_DIR} ]; then
-    IMAGE_GENERIC_DIR=${KERNEL_BASE_DIR}/linux-image-*-generic
-fi
-rsync -av ${IMAGE_GENERIC_DIR}/boot/ ${GENERIC_MAIN_DIR}/boot/
-rsync -av ${KERNEL_BASE_DIR}/linux-modules-[0-9]*-generic/boot/ ${GENERIC_MAIN_DIR}/boot/
-rsync -av ${KERNEL_BASE_DIR}/linux-modules-[0-9]*-generic/lib/ ${GENERIC_MAIN_DIR}/lib/
-rsync -av ${FIRMWARE_BASE_DIR}/ ${GENERIC_MAIN_DIR}/lib/firmware/
+dpkg-deb -x build/linux-image-unsigned-5.0.*.deb ${GENERIC_MAIN_DIR}
+dpkg-deb -x build/linux-modules-5.0*.deb ${GENERIC_MAIN_DIR}
+dpkg-deb -x ${DOWNLOADS}/ubuntu-firmware.deb ${GENERIC_MAIN_DIR}
 
 # extra modules
-rsync -av ${KERNEL_BASE_DIR}/linux-modules-extra-*-generic/lib/ ${GENERIC_EXTRA_DIR}/lib/
+dpkg-deb -x build/linux-modules-extra-5.0*.deb ${GENERIC_EXTRA_DIR}
 
 # package artifacts
 mkdir -p dist/artifacts

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -8,16 +8,14 @@ mkdir -p ${DOWNLOADS}/kernel ${DOWNLOADS}/firmware
 
 # kernel
 mkdir -p build/kernel
-curl -fL -o ${DOWNLOADS}/ubuntu-kernel.deb ${KERNEL_SOURCE_URL}
 dpkg-deb -x ${DOWNLOADS}/ubuntu-kernel.deb ${DOWNLOADS}/kernel
 rsync -a ${DOWNLOADS}/kernel/usr/src/linux-source-*/debian* ./build/kernel/
 tar xf ${DOWNLOADS}/kernel/usr/src/linux-source-*/linux-source*.tar.bz2 -C ./build/kernel/. --strip-components=1
 
-# firmware
-mkdir -p build/firmware
-curl -fL -o ${DOWNLOADS}/ubuntu-firmware.deb ${FIRMWARE_URL}
-dpkg-deb -x ${DOWNLOADS}/ubuntu-firmware.deb ${DOWNLOADS}/firmware
-rsync -a ${DOWNLOADS}/firmware/lib/firmware/* ./build/firmware/
+## firmware
+#mkdir -p build/firmware
+#dpkg-deb -x ${DOWNLOADS}/ubuntu-firmware.deb ${DOWNLOADS}/firmware
+#rsync -a ${DOWNLOADS}/firmware/lib/firmware/* ./build/firmware/
 
 # patches
 PATCHES_DIR=$(pwd)/patches


### PR DESCRIPTION
- use `apt-get download` to get firmware and kernel in multi-stage dapper
- add clean target