### PR TITLE
Ubuntu Focal LTS 5.4.0-42.46

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -4,8 +4,8 @@ ARG DOWNLOADS=/usr/src/downloads
 
 FROM ${UBUNTU} AS ubuntu
 ARG DOWNLOADS
-ARG LINUX_FIRMWARE=linux-firmware=1.187
-ARG LINUX_SOURCE=linux-source-5.4.0=5.4.0-37.41
+ARG LINUX_FIRMWARE=linux-firmware=1.187.2
+ARG LINUX_SOURCE=linux-source-5.4.0=5.4.0-42.46
 ENV DEBIAN_FRONTEND=noninteractive
 RUN set -x \
  && apt-get --assume-yes update \

--- a/patches/bpfilter-umh.patch
+++ b/patches/bpfilter-umh.patch
@@ -1,7 +1,19 @@
-diff -urbB kernel.unpatched/debian.master/config/config.common.ubuntu kernel/debian.master/config/config.common.ubuntu
---- kernel.unpatched/debian.master/config/config.common.ubuntu  2020-04-01 00:47:16.499541862 +0000
-+++ kernel/debian.master/config/config.common.ubuntu    2020-04-01 00:47:44.554871398 +0000
-@@ -1170,7 +1170,7 @@
+diff -urbB kernel.unpatched/debian.master/config/annotations kernel.bpfilter-umh/debian.master/config/annotations
+--- kernel.unpatched/debian.master/config/annotations	2020-07-09 23:50:26.000000000 +0000
++++ kernel.bpfilter-umh/debian.master/config/annotations	2020-08-05 17:59:22.792706399 +0000
+@@ -11825,7 +11825,7 @@
+ 
+ # Menu: Networking support >> Networking options >> TCP/IP networking >> BPF based packet filtering framework (BPFILTER)
+ CONFIG_BPFILTER                                 policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'i386': 'y', 'ppc64el': 'y', 's390x': 'y'}>
+-CONFIG_BPFILTER_UMH                             policy<{'amd64': 'm', 'arm64': 'm', 'armhf': 'm', 'i386': 'm', 'ppc64el': 'm', 's390x': 'm'}>
++CONFIG_BPFILTER_UMH                             policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'i386': 'y', 'ppc64el': 'y', 's390x': 'y'}>
+ 
+ # Menu: Networking support >> Networking options >> TCP/IP networking >> INET: socket monitoring interface
+ CONFIG_INET_DIAG                                policy<{'amd64': 'm', 'arm64': 'm', 'armhf': 'm', 'i386': 'm', 'ppc64el': 'm', 's390x': 'm'}>
+diff -urbB kernel.unpatched/debian.master/config/config.common.ubuntu kernel.bpfilter-umh/debian.master/config/config.common.ubuntu
+--- kernel.unpatched/debian.master/config/config.common.ubuntu	2020-07-09 23:50:26.000000000 +0000
++++ kernel.bpfilter-umh/debian.master/config/config.common.ubuntu	2020-08-05 17:57:02.474005780 +0000
+@@ -1169,7 +1169,7 @@
  CONFIG_BOOT_PRINTK_DELAY=y
  CONFIG_BPF=y
  CONFIG_BPFILTER=y

--- a/patches/ikconfig-proc.patch
+++ b/patches/ikconfig-proc.patch
@@ -1,7 +1,19 @@
-diff -urbB kernel.unpatched/debian.master/config/config.common.ubuntu kernel/debian.master/config/config.common.ubuntu
---- kernel.unpatched/debian.master/config/config.common.ubuntu  2020-04-01 00:47:16.499541862 +0000
-+++ kernel/debian.master/config/config.common.ubuntu    2020-04-01 00:47:44.554871398 +0000
-@@ -4311,7 +4311,8 @@
+diff -urbB kernel.unpatched/debian.master/config/annotations kernel.ikconfig/debian.master/config/annotations
+--- kernel.unpatched/debian.master/config/annotations	2020-07-09 23:50:26.000000000 +0000
++++ kernel.ikconfig/debian.master/config/annotations	2020-08-05 18:03:31.941519468 +0000
+@@ -10281,7 +10281,7 @@
+ CONFIG_USELIB                                   policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'i386': 'y', 'ppc64el': 'y', 's390x': 'y'}>
+ CONFIG_AUDIT                                    policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'i386': 'y', 'ppc64el': 'y', 's390x': 'y'}>
+ CONFIG_CPU_ISOLATION                            policy<{'amd64': 'y', 'arm64': 'y', 'armhf': 'y', 'i386': 'y', 'ppc64el': 'y', 's390x': 'y'}>
+-CONFIG_IKCONFIG                                 policy<{'amd64': 'n', 'arm64': 'n', 'armhf': 'n', 'i386': 'n', 'ppc64el': 'n', 's390x': 'n'}>
++CONFIG_IKCONFIG                                 policy<{'amd64': 'm', 'arm64': 'm', 'armhf': 'm', 'i386': 'm', 'ppc64el': 'm', 's390x': 'm'}>
+ CONFIG_IKHEADERS                                policy<{'amd64': 'm', 'arm64': 'm', 'armhf': 'm', 'i386': 'm', 'ppc64el': 'm', 's390x': 'm'}>
+ CONFIG_LOG_BUF_SHIFT                            policy<{'amd64': '18', 'arm64': '18', 'armhf': '17', 'i386': '17', 'ppc64el': '18', 's390x': '18'}>
+ CONFIG_LOG_CPU_MAX_BUF_SHIFT                    policy<{'amd64': '12', 'arm64': '12', 'armhf': '12', 'i386': '12', 'ppc64el': '12', 's390x': '12'}>
+diff -urbB kernel.unpatched/debian.master/config/config.common.ubuntu kernel.ikconfig/debian.master/config/config.common.ubuntu
+--- kernel.unpatched/debian.master/config/config.common.ubuntu	2020-07-09 23:50:26.000000000 +0000
++++ kernel.ikconfig/debian.master/config/config.common.ubuntu	2020-08-05 18:02:22.992185660 +0000
+@@ -4304,7 +4304,8 @@
  CONFIG_IIO_TRIGGER=y
  CONFIG_IIO_TRIGGERED_BUFFER=m
  CONFIG_IIO_TRIGGERED_EVENT=m

--- a/scripts/build
+++ b/scripts/build
@@ -21,5 +21,5 @@ for abi in $(find . -mindepth 1 -maxdepth 2 -type d -name abi); do
         echo bpfilter > $ver/modules.ignore
     done
 done
-debian/rules binary-headers binary-generic do_zfs=false do_dkms_nvidia=false #skipmodule=true
+debian/rules binary-headers binary-generic do_zfs=false do_dkms_nvidia=false do_dkms_nvidia_server=false
 popd


### PR DESCRIPTION
- linux-firmware 1.187.2
- build with `do_dkms_nvidia_server=false`
- updated module patches to account for policy checks