### PR TITLE
ubuntu lts kernel 5.4.0-73.82

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -4,8 +4,8 @@ ARG DOWNLOADS=/usr/src/downloads
 
 FROM ${UBUNTU} AS ubuntu
 ARG DOWNLOADS
-ARG LINUX_FIRMWARE=linux-firmware=1.187.11
-ARG LINUX_SOURCE=linux-source-5.4.0=5.4.0-72.80
+ARG LINUX_FIRMWARE=linux-firmware=1.187.12
+ARG LINUX_SOURCE=linux-source-5.4.0=5.4.0-73.82
 ENV DEBIAN_FRONTEND=noninteractive
 RUN set -x \
  && apt-get --assume-yes update \

--- a/patches/ahc1ec0.patch
+++ b/patches/ahc1ec0.patch
@@ -1,0 +1,27 @@
+diff -urbB kernel.unpatched/debian.master/config/annotations kernel.ahce1c0/debian.master/config/annotations
+--- kernel.unpatched/debian.master/config/annotations	2021-04-14 16:35:30.000000000 +0000
++++ kernel.ahce1c0/debian.master/config/annotations	2021-05-27 21:06:25.366108765 +0000
+@@ -2615,7 +2615,6 @@
+ CONFIG_SENSORS_WM831X                           policy<{'amd64': 'm', 'arm64': 'm', 'armhf': 'm', 'i386': 'm', 'ppc64el': 'm'}>
+ CONFIG_SENSORS_WM8350                           policy<{'amd64': 'm', 'arm64': 'm', 'armhf': 'm', 'i386': 'm', 'ppc64el': 'm'}>
+ CONFIG_SENSORS_XGENE                            policy<{'amd64': 'm', 'arm64': 'm', 'i386': 'm'}>
+-CONFIG_SENSORS_AHC1EC0_HWMON                    policy<{'amd64': 'm'}>
+ CONFIG_SENSORS_ACPI_POWER                       policy<{'amd64': 'm', 'arm64': 'm', 'i386': 'm'}>
+ CONFIG_SENSORS_ATK0110                          policy<{'amd64': 'm', 'i386': 'm'}>
+ 
+@@ -4366,7 +4365,6 @@
+ CONFIG_MFD_STMFX                                policy<{'arm64': 'm', 'armhf': 'm', 'ppc64el': 'm'}>
+ CONFIG_MFD_VEXPRESS_SYSREG                      policy<{'arm64': 'y', 'armhf': 'y'}>
+ CONFIG_RAVE_SP_CORE                             policy<{'amd64': 'm', 'arm64': 'm', 'armhf': 'm', 'i386': 'm', 'ppc64el': 'm', 's390x': 'n'}>
+-CONFIG_MFD_AHC1EC0                              policy<{'amd64': 'm'}>
+ #
+ CONFIG_MFD_SM501                                note<boot essential on OMAP4>
+ CONFIG_MFD_TPS65217                             mark<ENFORCED> note<boot essential on AM335x>
+@@ -9483,7 +9481,6 @@
+ CONFIG_INTEL_MEI_WDT                            policy<{'amd64': 'm', 'i386': 'm'}>
+ CONFIG_NI903X_WDT                               policy<{'amd64': 'm', 'i386': 'm'}>
+ CONFIG_NIC7018_WDT                              policy<{'amd64': 'm', 'i386': 'm'}>
+-CONFIG_AHC1EC0_WDT                              policy<{'amd64': 'm'}>
+ CONFIG_BCM2835_WDT                              policy<{'arm64': 'm'}>
+ CONFIG_BCM7038_WDT                              policy<{'arm64': 'm'}>
+ CONFIG_MEN_A21_WDT                              policy<{'amd64': 'm', 'arm64': 'm', 'armhf': 'm', 'i386': 'm', 'ppc64el': 'm', 's390x': 'm'}>

--- a/patches/apparmor.patch
+++ b/patches/apparmor.patch
@@ -1,0 +1,11 @@
+diff -urbB kernel.unpatched/debian.master/config/config.common.ubuntu kernel.apparmor/debian.master/config/config.common.ubuntu
+--- kernel.unpatched/debian.master/config/config.common.ubuntu	2021-04-14 16:35:30.000000000 +0000
++++ kernel.apparmor/debian.master/config/config.common.ubuntu	2021-05-27 19:21:07.766817302 +0000
+@@ -8508,6 +8508,7 @@
+ CONFIG_SECURITY=y
+ CONFIG_SECURITYFS=y
+ CONFIG_SECURITY_APPARMOR=y
++CONFIG_SECURITY_APPARMOR_BOOTPARAM_VALUE=0
+ # CONFIG_SECURITY_APPARMOR_DEBUG is not set
+ CONFIG_SECURITY_APPARMOR_HASH=y
+ CONFIG_SECURITY_APPARMOR_HASH_DEFAULT=y

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -20,6 +20,9 @@ tar xf ${DOWNLOADS}/kernel/usr/src/linux-source-*/linux-source*.tar.bz2 -C ./bui
 #rsync -a ${DOWNLOADS}/firmware/lib/firmware/* ./build/firmware/
 
 # patches
+if [ -n "${NOPATCHES}" ]; then
+    exit 0
+fi
 PATCHES_DIR=$(pwd)/patches
 pushd build/kernel
 for p in `find ${PATCHES_DIR} -name "*.patch"`; do


### PR DESCRIPTION
- linux-source-5.4.0: 5.4.0-73.82
- linux-firmware: 1.187.12
- ignore anootation-based checks for ahce1c0 modules
- adjust default apparmor boot parameter to leave it disabled

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
