### PR TITLE
Feature/wireguard

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -7,23 +7,23 @@ ARG LINUX_SOURCE=linux-source-5.0.0=5.0.0-47.51~18.04.1
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN set -x \
- && apt-get --assume-yes update \
- && apt-get --assume-yes download \
+    && apt-get --assume-yes update \
+    && apt-get --assume-yes download \
     ${LINUX_FIRMWARE} \
     ${LINUX_SOURCE} \
- && mkdir -vp ${DOWNLOADS} \
- && mv -vf linux-firmware* ${DOWNLOADS}/ubuntu-firmware.deb \
- && mv -vf linux-source* ${DOWNLOADS}/ubuntu-kernel.deb
+    && mkdir -vp ${DOWNLOADS} \
+    && mv -vf linux-firmware* ${DOWNLOADS}/ubuntu-firmware.deb \
+    && mv -vf linux-source* ${DOWNLOADS}/ubuntu-kernel.deb
 
 FROM ${APT_GCC}
 ARG DOWNLOADS=/usr/src/downloads
 # Wireguard support, included in Linux in 5.6+
-ARG WG_URL="https://git.zx2c4.com"
+ARG WG_URL="https://github.com/1898andCo/"
 ARG WG_REPO="wireguard-linux-compat"
-ARG WG_TAG=v1.0.20200413
+ARG WG_TAG=v1.0.20220627
 COPY --from=bionic ${DOWNLOADS}/ ${DOWNLOADS}/
 RUN apt-get update \
- && apt-get install -y \
+    && apt-get install -y \
     kernel-wedge \
     libncurses-dev \
     fakeroot \
@@ -41,7 +41,7 @@ RUN apt-get update \
     gawk  \
     libudev-dev \
     pciutils-dev \
- && rm -f /bin/sh && ln -s /bin/bash /bin/sh
+    && rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
 ########## Dapper Configuration #####################
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# The Kernel of K3OS
+# The Kernel of HAOS
 This repo can build the kernel and package the firmware.
 
 # License
 Copyright (c) 2019-2020 [Rancher Labs, Inc.](http://rancher.com)
+Copyright (c) 2023 [1898 & Co](http://1898andco.com)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This repo can build the kernel and package the firmware.
 
 # License
 Copyright (c) 2019-2020 [Rancher Labs, Inc.](http://rancher.com)
-Copyright (c) 2023 [1898 & Co](http://1898andco.com)
+Copyright (c) 2023 [1898 & Co](http://1898andco..burnsmcd.com)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
changes wireguard library to pull from 1898 repo

I needed to do this as the existing repo lacked a certificate, so I was unable to clone the repo in the script that called for it.

(the other option was to turn off checking for certs then turn it back on, which I was not comfortable with)